### PR TITLE
Fix code generation for empty message types

### DIFF
--- a/src/Data/ProtoBufInt.hs
+++ b/src/Data/ProtoBufInt.hs
@@ -41,7 +41,7 @@ import Data.Sequence         as Export (Seq)
 import Data.Set              as Export (fromList)
 import Data.Text.Lazy        as Export (Text, pack)
 import Data.Word             as Export (Word32, Word64)
-import Prelude               as Export (Double, Eq, Float, Ord, Show)
+import Prelude               as Export (Double, Eq, Float, Ord, Show, return)
 
 
 -- | Append a value to a Seq.


### PR DESCRIPTION
Currently, it generates an empty `do`, which does not compile.

Same as before: I'm not sure if the spec allows empty types, but it shouldn't break anything either way.